### PR TITLE
fix compute_cost_per_minute

### DIFF
--- a/.changes/unreleased/Fixes-20241116-185934.yaml
+++ b/.changes/unreleased/Fixes-20241116-185934.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix composte cost per minute that would override latest hour because it is leveraging insert_overwrite.
+time: 2024-11-16T18:59:34.210365+01:00
+custom:
+    Author: Kayrnt
+    Issue: ""

--- a/models/compute/intermediate/cost/compute_cost_per_minute.sql
+++ b/models/compute/intermediate/cost/compute_cost_per_minute.sql
@@ -30,5 +30,5 @@ SELECT
     COUNTIF(state = 'RUNNING') AS running,
     COUNTIF(state = 'PENDING') AS pending
   ) AS job_state
-FROM {{ jobs_done_incremental_minute() }}
+FROM {{ jobs_done_incremental_hourly() }}
 GROUP BY ALL


### PR DESCRIPTION
`compute_cost_per_minute` model is partitioned by hour and leverage insert_overwrite so let's assume we have following setup:
- First run at 1:30 AM, we get the data from 0 to 1:30
- Then we run again at 3 AM
- The model will read max partition = 1:30 AM
- With former version, it would truncate at the minute then we read 1:30 to 2 AM but with the fixed one we will read from 1 AM to 2 AM.
- With that data, we apply the group by minute and store the result on the 1 AM partition

So if we don't apply that fix, the second run would remove the data from 1 AM to 1:30 AM ending up with partial data.