### PR TITLE
Update dbt version constraint to support dbt Fusion

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 name: "dbt_bigquery_monitoring"
 version: "0.23.1"
-require-dbt-version: [">=1.3.0", "<2.0.0"]
+require-dbt-version: [">=1.3.0", "<3.0.0"]
 config-version: 2
 
 profile: dbt_bigquery_monitoring
@@ -12,7 +12,6 @@ clean-targets:
   - dbt_packages
 
 models:
-  +start: Jan 1 2017
   dbt_bigquery_monitoring:
     +tags:
       - "dbt-bigquery-monitoring"


### PR DESCRIPTION
Update require-dbt-version upper bound from <2.0.0 to <3.0.0 to mark
this package as compatible with dbt Fusion.
