### PR TITLE
Scope compute cost incrementals to recent partitions only

### DIFF
--- a/.changes/unreleased/Fixes-20260602-102700.yaml
+++ b/.changes/unreleased/Fixes-20260602-102700.yaml
@@ -1,0 +1,2 @@
+kind: Fixes
+body: Scope compute cost per minute and per hour incrementals to partitions from the current max partition onward

--- a/macros/compute_incremental_minute_filter.sql
+++ b/macros/compute_incremental_minute_filter.sql
@@ -1,0 +1,9 @@
+{#
+  Limit incremental insert_overwrite models partitioned on minute (hour granularity)
+  to partitions at or after the current max partition.
+#}
+{% macro compute_incremental_minute_filter(timestamp_column='minute') %}
+  {% if is_incremental() %}
+  WHERE {{ timestamp_column }} >= {{ get_partition_timestamp() }}
+  {% endif %}
+{% endmacro %}

--- a/models/monitoring/compute/intermediate/cost/compute_cost_per_hour.sql
+++ b/models/monitoring/compute/intermediate/cost/compute_cost_per_hour.sql
@@ -33,4 +33,5 @@ SELECT
     SUM(job_state.pending) AS pending
   ) AS job_state
 FROM {{ ref("compute_cost_per_minute") }}
+{{ compute_incremental_minute_filter('minute') }}
 GROUP BY ALL

--- a/models/monitoring/compute/intermediate/cost/compute_cost_per_minute.sql
+++ b/models/monitoring/compute/intermediate/cost/compute_cost_per_minute.sql
@@ -33,4 +33,5 @@ SELECT
     SUM(job_state.pending) AS pending
   ) AS job_state
 FROM {{ ref('compute_rollup_per_minute') }}
+{{ compute_incremental_minute_filter('minute') }}
 GROUP BY ALL


### PR DESCRIPTION
Add compute_incremental_minute_filter so compute_cost_per_minute and compute_cost_per_hour only read and overwrite partitions from the current max partition onward on incremental runs.