### PR TITLE
Fix project_by_project_table leaking __dbt_tmp tables

### DIFF
--- a/.changes/unreleased/Fixes-20260717-200046.yaml
+++ b/.changes/unreleased/Fixes-20260717-200046.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Drop the schema-check temp table after use in project_by_project_table to stop leaking __dbt_tmp tables on incremental runs
+time: 2026-07-17T20:00:46-10:00
+custom:
+    Author: Kayrnt
+    Issue: "197"

--- a/macros/project_by_project_table.sql
+++ b/macros/project_by_project_table.sql
@@ -58,6 +58,7 @@
   {% set build_sql = create_table_as(False, tmp_relation, sql_no_data) %}
   {% do run_query(build_sql) %}
   {% set dest_columns = process_schema_changes('sync_all_columns', tmp_relation, existing_relation) %}
+  {% do adapter.drop_relation(tmp_relation) %}
 
 {% endif %}
 


### PR DESCRIPTION
## Summary
- Drop the schema-check temp relation after `process_schema_changes` in `project_by_project_table`, matching dbt-bigquery's incremental materialization cleanup.
- Stops orphaned `<model>__dbt_tmp…` tables from accumulating on every multi-project incremental run.

Fixes #197

## Test plan
- [ ] Run an `information_schema_*` model with `project_by_project_table` once to create the target
- [ ] Run it again (incremental, no `--full-refresh`)
- [ ] Confirm no new `__dbt_tmp` table remains in the target dataset:
  ```sql
  select table_name, creation_time
  from `<project>.<dataset>.INFORMATION_SCHEMA.TABLES`
  where regexp_contains(table_name, r'__dbt_tmp')
  order by creation_time desc;
  ```